### PR TITLE
(fix) AMI cleaner throwing InvalidLaunchTemplateName.NotFoundException

### DIFF
--- a/amicleaner/cli.py
+++ b/amicleaner/cli.py
@@ -50,7 +50,9 @@ class App(object):
 
         if not excluded_amis:
             excluded_amis += f.fetch_unattached_lc()
-            excluded_amis += f.fetch_zeroed_asg()
+            excluded_amis += f.fetch_unattached_lt()
+            excluded_amis += f.fetch_zeroed_asg_lc()
+            excluded_amis += f.fetch_zeroed_asg_lt()
             excluded_amis += f.fetch_instances()
 
         candidates = [v

--- a/amicleaner/fetch.py
+++ b/amicleaner/fetch.py
@@ -51,12 +51,41 @@ class Fetcher(object):
         resp = self.asg.describe_launch_configurations(
             LaunchConfigurationNames=unused_lcs
         )
+
         amis = [lc.get("ImageId")
                 for lc in resp.get("LaunchConfigurations", [])]
 
+
         return amis
 
-    def fetch_zeroed_asg(self):
+    def fetch_unattached_lt(self):
+
+        """
+        Find AMIs for launch templates unattached
+        to autoscaling groups
+        """
+
+        resp = self.asg.describe_auto_scaling_groups()
+        used_lt = (asg.get("LaunchTemplate", {}).get("LaunchTemplateName")
+                   for asg in resp.get("AutoScalingGroups", []))
+
+        resp = self.ec2.describe_launch_templates()
+        all_lts = (lt.get("LaunchTemplateName", "")
+                   for lt in resp.get("LaunchTemplates", []))
+
+        unused_lts = list(set(all_lts) - set(used_lt))
+
+        amis = []
+        for lt_name in unused_lts:
+            resp = self.ec2.describe_launch_template_versions(
+                LaunchTemplateName=lt_name
+            )
+            amis.append(lt_latest_version.get("LaunchTemplateData", {}).get("ImageId")
+                        for lt_latest_version in resp.get("LaunchTemplateVersions", []))
+
+        return amis
+
+    def fetch_zeroed_asg_lc(self):
 
         """
         Find AMIs for autoscaling groups who's desired capacity is set to 0
@@ -65,7 +94,7 @@ class Fetcher(object):
         resp = self.asg.describe_auto_scaling_groups()
         zeroed_lcs = [asg.get("LaunchConfigurationName", "")
                       for asg in resp.get("AutoScalingGroups", [])
-                      if asg.get("DesiredCapacity", 0) == 0]
+                      if asg.get("DesiredCapacity", 0) == 0 and len(asg.get("LaunchConfigurationNames", [])) > 0]
 
         resp = self.asg.describe_launch_configurations(
             LaunchConfigurationNames=zeroed_lcs
@@ -73,6 +102,39 @@ class Fetcher(object):
 
         amis = [lc.get("ImageId", "")
                 for lc in resp.get("LaunchConfigurations", [])]
+
+        return amis
+    
+    def fetch_zeroed_asg_lt(self):
+
+        """
+        Find AMIs for autoscaling groups who's desired capacity is set to 0
+        """
+
+        resp = self.asg.describe_auto_scaling_groups()
+        # This does not support multiple versions of the same launch template being used
+        zeroed_lts = [asg.get("LaunchTemplate", {})
+                      for asg in resp.get("AutoScalingGroups", [])
+                      if asg.get("DesiredCapacity", 0) == 0]
+
+        zeroed_lt_names = [lt.get("LaunchTemplateName", "")
+                        for lt in zeroed_lts]
+
+        zeroed_lt_versions = [lt.get("LaunchTemplateVersion", "")
+                        for lt in zeroed_lts]
+
+        resp = self.ec2.describe_launch_templates(
+            LaunchTemplateNames=zeroed_lt_names
+        )
+
+        amis = []
+        for lt_name, lt_version in zip(zeroed_lt_names, zeroed_lt_versions):
+            resp = self.ec2.describe_launch_template_versions(
+                LaunchTemplateName=lt_name
+                # Cannot be empty... Versions=[lt_version] - unsure how to pass param only if present in Python 
+            )
+            amis.append(lt_latest_version.get("LaunchTemplateData", {}).get("ImageId")
+                        for lt_latest_version in resp.get("LaunchTemplateVersions", []))
 
         return amis
 


### PR DESCRIPTION
### Description of Changes

The following error is occurring in the Cleanup snapshots & AMIs stage of the deploy task:

![image](https://github.com/TandaHQ/aws-amicleaner/assets/127071700/caadc17c-0a2c-4f82-9ef0-08bbb019cd5d)
```
botocore.exceptions.ClientError: An error occurred (InvalidLaunchTemplateName.NotFoundException) when calling the DescribeLaunchTemplateVersions operation: The specified launch template, with template name core-app-staging-149c95a5-0d76-a2be-5e76-737195019d9e, does not exist.
```

I believe what is happening here is that the bakery gem has already trigger a deletion of the old launch template, but describe_launch_templates is still returning it (the APIs are quite syncronous). By the time we get to describe_launch_template_versions the launch template is actually gone.

The change is just to put some error handling around this.

Note: we want to merge into the feature branch since this is the thing baked into the docker image:
![image](https://github.com/TandaHQ/aws-amicleaner/assets/127071700/cdf2b941-ff2d-415c-b2ed-06cf127662d7)
Changing the branch name would require baking a new round of docker images.

### QA

#### Test error handling logic
Since it would be difficult to simulate the exact conditions where the launch template isn't found, I just setup an artificial test with some cut down code in test_error_handling.py (running in tandahq/circleci-payaus:2.7.7 so binary versions are the same):
![image](https://github.com/TandaHQ/aws-amicleaner/assets/127071700/d3d981b3-f4cb-46d2-b8ce-911b26f4b784)

And tested 2 scenarios, 1 were the the template name was invalid, and 2 where the template name was valid. Both passed successfully:
![image](https://github.com/TandaHQ/aws-amicleaner/assets/127071700/1a51580d-0c14-4a84-927d-c3d4f3538f70)


#### Test for syntax/formatting/typo breakage
Patching the exact changes made in this PR into the library and ensure it still runs:
![image](https://github.com/TandaHQ/aws-amicleaner/assets/127071700/ff4ac611-57aa-4722-a504-30e3dded55d5)

![image](https://github.com/TandaHQ/aws-amicleaner/assets/127071700/609790e7-3ced-43d8-bbdf-ce2586c0cccd)



